### PR TITLE
Add z-index variable for higher up modals like cookie banner

### DIFF
--- a/config/z-indices.scss
+++ b/config/z-indices.scss
@@ -3,3 +3,4 @@ $z-popup: 1010;
 $z-layout: 1020;
 $z-modal-backdrop: 1030;
 $z-modal: 1040;
+$z-modal-banner: 1050;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "homepage": "https://nebenan.de/",
   "repository": "good-hood-gmbh/nebenan-ui-kit",
   "bugs": "https://github.com/good-hood-gmbh/nebenan-ui-kit/issues",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "files": [
     "config/*.scss",
     "config/*/*.scss",


### PR DESCRIPTION
<img width="1082" alt="Screenshot 2021-05-10 at 12 28 40" src="https://user-images.githubusercontent.com/34499633/117649269-9ef18480-b18f-11eb-9aad-e046a762b37b.png">

Like here. It won't look very nice but the cookie banner has a higher priority then the email confirmation modal.

Open for naming suggestions